### PR TITLE
Update .gitignore to exclude 'app' directory instead or 'api'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 dockerapi/db/
-dockerapi/api/__pycache__
+dockerapi/app/__pycache__


### PR DESCRIPTION
.gitignoreファイルに記載している__pycache__のパスをdockerapi/api/__pycache__からdockerapi/app/__pycache__に変更